### PR TITLE
ImVec operators.

### DIFF
--- a/ElecDev_Graphics_Application/Source/Engines/Design2DEngine/Design2DEngine_Events.cpp
+++ b/ElecDev_Graphics_Application/Source/Engines/Design2DEngine/Design2DEngine_Events.cpp
@@ -103,10 +103,6 @@ void Design2DEngine::onMouseMoveEvent(MouseMoveEvent& event)
 {
 	Base2DEngine::onMouseMoveEvent(event);
 
-	glm::vec2 mousePos = getMousePosition();
-	std::cout << "\n" << mousePos.x << " , " << mousePos.y << "\n";
-
-
 	uint64_t eventID = event.ID;
 
 	glm::vec2 coords = event.mousePosition;

--- a/ElecDev_Graphics_Application/Source/External/ImGUI/Core/imconfig.h
+++ b/ElecDev_Graphics_Application/Source/External/ImGUI/Core/imconfig.h
@@ -79,15 +79,16 @@
 
 //---- Define constructor and implicit cast operators to convert back<>forth between your math types and ImVec2/ImVec4.
 // This will be inlined as part of ImVec2 and ImVec4 class declarations.
-/*
-#define IM_VEC2_CLASS_EXTRA                                                 \
-        ImVec2(const MyVec2& f) { x = f.x; y = f.y; }                       \
-        operator MyVec2() const { return MyVec2(x,y); }
 
-#define IM_VEC4_CLASS_EXTRA                                                 \
-        ImVec4(const MyVec4& f) { x = f.x; y = f.y; z = f.z; w = f.w; }     \
-        operator MyVec4() const { return MyVec4(x,y,z,w); }
-*/
+#include "External/GLM/glm.hpp"
+
+#define IM_VEC2_CLASS_EXTRA                                                     \
+        ImVec2(const glm::vec2& f) { x = f.x; y = f.y; }                        \
+        operator glm::vec2() const { return glm::vec2(x,y); }
+
+#define IM_VEC4_CLASS_EXTRA                                                     \
+        ImVec4(const glm::vec4& f) { x = f.x; y = f.y; z = f.z; w = f.w; }      \
+        operator glm::vec4() const { return glm::vec4(x,y,z,w); }
 
 //---- Use 32-bit vertex indices (default is 16-bit) is one way to allow large meshes with more than 64K vertices.
 // Your renderer backend will need to support it (most example renderer backends support both 16/32-bit indices).

--- a/ElecDev_Graphics_Application/Source/GUI/GuiElementCore/GuiElementCore.cpp
+++ b/ElecDev_Graphics_Application/Source/GUI/GuiElementCore/GuiElementCore.cpp
@@ -128,9 +128,7 @@ void GuiElementCore::onContentRegionMoveEvent(WindowEvent& event)
 void GuiElementCore::detectContentRegionResize() 
 {
 	// Get the current content region size.
-	ImVec2 contentRegionSizeIm = m_imguiWindow->ContentRegionRect.GetSize();
-	glm::vec2 contentRegionSize = { contentRegionSizeIm.x, contentRegionSizeIm.y};
-
+	glm::vec2 contentRegionSize = m_imguiWindow->ContentRegionRect.GetSize();
 	// If the content region resized pass an event.
 	if (m_contentRegionSize.x != contentRegionSize.x || m_contentRegionSize.y != contentRegionSize.y)
 	{
@@ -142,11 +140,9 @@ void GuiElementCore::detectContentRegionResize()
 void GuiElementCore::detectContentRegionMove()
 {
 	// Get window current position.
-	ImVec2 regionPos = m_imguiWindow->ContentRegionRect.Min;
-	glm::vec2 contentRegionPos = { regionPos.x, regionPos.y };
-
+	glm::vec2 contentRegionPos = m_imguiWindow->ContentRegionRect.Min;
 	// Check if the window has moved.
-	if(m_contentRegionPosition.x != regionPos.x || m_contentRegionPosition.y != regionPos.y)
+	if(m_contentRegionPosition.x != contentRegionPos.x || m_contentRegionPosition.y != contentRegionPos.y)
 	{
 		WindowEvent event(contentRegionPos, EventType_WindowMove);
 		onEvent(event);


### PR DESCRIPTION
We can now use `ImVec` and `glm::vec` interchangeably.